### PR TITLE
feat: 포스트 조회에 커서 페이지네이션 적용

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,112 @@
+language: ko-KR
+
+early_access: true
+enable_free_tier: true
+reviews:
+  profile: chill
+  request_changes_workflow: true
+  high_level_summary: true
+  high_level_summary_placeholder: '@coderabbitai 요약'
+  auto_title_placeholder: '@coderabbitai'
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  path_filters:
+    - "!**/README.md"
+  path_instructions:
+    - path: "**"
+      instructions: >
+        Review the API endpoints based on this guidelines.
+        
+        ### Richardson Maturity Model (RMM)
+        1. Level 0: Single URI with POST requests for all actions.
+        2. Level 1: Separate URIs for individual resources.
+        3. Level 2: Use of HTTP methods (GET, POST, PUT, DELETE) to define operations on resources.
+        4. Level 3: Hypermedia (HATEOAS) for advanced RESTful APIs.
+        
+        ### API Conventions
+        - URI Rules:
+          - Should be intuitive and self-explanatory.
+          - Should not map 1:1 to database tables.
+          - Must be stateless, with no session state between requests.
+          - Include "api" and version in the URI (/api/{version}/resource).
+          - Use kebab-case for URIs and camelCase for parameters and body contents.
+          - Resource identifiers should be unique and only one per URI path.
+        
+        - Design Principles:
+          - APIs should be designed around resources, which are abstractions rather than direct database tables.
+          - Stateless APIs facilitate scalability and flexibility.
+          - Clear separation of frontend and backend via URI structure.
+          - Versioning in URI paths is preferred for clarity and ease of caching.
+          - Maintain consistent naming conventions across the API.
+          - Use plural forms for resource names (/users instead of /user).
+          - Complex actions can include verbs in the URI (/orders/{orderId}/cancel).
+        
+        - Implementation Details:
+          - Avoid deeply nested resource paths to ensure maintainability.
+          - Ensure URIs reflect the data they provide, not the permissions or roles required to access them.
+          - Keep URIs simple and predictable, aiding both developers and automated systems.
+  abort_on_close: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: []
+    labels: []
+    drafts: false
+    base_branches: []
+  tools:
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      disabled_rules:
+        - EN_UNPAIRED_BRACKETS
+        - EN_UNPAIRED_QUOTES
+      disabled_categories:
+        - TYPOS
+        - TYPOGRAPHY
+        - CASING
+      enabled_only: false
+      level: default
+      enabled_rules: []
+      enabled_categories: []
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: default
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    checkov:
+      enabled: true
+    ast-grep:
+      packages: []
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+chat:
+  auto_reply: true
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  jira:
+    project_keys: []
+  linear:
+    team_keys: []

--- a/src/main/kotlin/com/example/blog/config/extensions.kt
+++ b/src/main/kotlin/com/example/blog/config/extensions.kt
@@ -1,5 +1,0 @@
-package com.example.blog.config
-
-import java.util.*
-
-fun <T : Any> Iterable<T>.firstOptional(): Optional<T> = Optional.ofNullable(firstOrNull())

--- a/src/main/kotlin/com/example/blog/config/utils.kt
+++ b/src/main/kotlin/com/example/blog/config/utils.kt
@@ -11,8 +11,8 @@ fun <T : Any> Iterable<T>.firstOptional(): Optional<T> = Optional.ofNullable(fir
 object Base64ObjectMapper {
     private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
-    fun toBase64(): String {
-        val json = objectMapper.writeValueAsString(this)
+    fun toBase64(obj: Any): String {
+        val json = objectMapper.writeValueAsString(obj)
         return Base64.getUrlEncoder().encodeToString(json.toByteArray())
     }
 

--- a/src/main/kotlin/com/example/blog/config/utils.kt
+++ b/src/main/kotlin/com/example/blog/config/utils.kt
@@ -1,0 +1,24 @@
+package com.example.blog.config
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.util.*
+
+fun <T : Any> Iterable<T>.firstOptional(): Optional<T> = Optional.ofNullable(firstOrNull())
+
+object Base64ObjectMapper {
+    private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    fun toBase64(): String {
+        val json = objectMapper.writeValueAsString(this)
+        return Base64.getUrlEncoder().encodeToString(json.toByteArray())
+    }
+
+    fun <T> fromBase64(base64String: String): T {
+        val decoded = String(Base64.getUrlDecoder().decode(base64String))
+
+        return objectMapper.readValue(decoded, object : TypeReference<T>() {})
+    }
+}

--- a/src/main/kotlin/com/example/blog/dto/PostModels.kt
+++ b/src/main/kotlin/com/example/blog/dto/PostModels.kt
@@ -17,3 +17,8 @@ data class PostDto(
     val content: String,
     val comments: List<CommentDto>
 )
+
+data class GetPostsResponse(
+    val posts: List<PostDto>,
+    val cursor: String
+)

--- a/src/main/kotlin/com/example/blog/dto/PostModels.kt
+++ b/src/main/kotlin/com/example/blog/dto/PostModels.kt
@@ -20,5 +20,12 @@ data class PostDto(
 
 data class GetPostsResponse(
     val posts: List<PostDto>,
-    val cursor: String
+    val cursor: String?
+)
+
+data class PostCursor(
+    val id: Long,
+    val title: String?,
+    val category: String?,
+    val createdAt: LocalDateTime,
 )

--- a/src/main/kotlin/com/example/blog/post/controllers/PostController.kt
+++ b/src/main/kotlin/com/example/blog/post/controllers/PostController.kt
@@ -39,6 +39,13 @@ class PostController(
         return postService.getPosts(pageable, title, category)
     }
 
+    @GetMapping(params = ["cursor"])
+    fun getPostsByCursor(
+        @RequestParam cursor: String,
+    ): GetPostsResponse {
+        TODO()
+    }
+
     @GetMapping("/{id}")
     fun getPost(@PathVariable("id") id: Long): PostDto {
         return postService.getPost(id)

--- a/src/main/kotlin/com/example/blog/post/infrastuctures/PostRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/blog/post/infrastuctures/PostRepositoryImpl.kt
@@ -7,10 +7,8 @@ import com.example.blog.post.domains.PostDomain
 import com.example.blog.post.services.ports.PostRepository
 import org.jetbrains.exposed.dao.load
 import org.jetbrains.exposed.sql.*
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.*
 
 @Repository
@@ -43,26 +41,24 @@ class PostRepositoryImpl : PostRepository {
     }
 
     override fun getByTitleAndCategory(
-        pageable: Pageable,
-        title: Optional<String>,
-        category: Optional<String>
-    ): Page<PostDomain> {
+        limit: Int,
+        title: String?,
+        category: String?,
+        lastId: Long?,
+        lastCreatedAt: LocalDateTime?
+    ): List<PostDomain> {
         val query = Posts
             .select { Posts.deleted eq false }
             .andWhere(title) { Posts.title like "%$it%" }
             .andWhere(category) { Posts.category eq it }
-            .orderBy(Posts.createdAt to SortOrder.DESC)
+            .andWhere(lastId) { Posts.id less it }
+            .andWhere(lastCreatedAt) { Posts.createdAt less it }
+            .orderBy(Posts.createdAt to SortOrder.DESC, Posts.id to SortOrder.DESC)
 
         PostDao.find { Posts.deleted eq false }
-        if (pageable.isPaged) query.limit(pageable.pageSize, pageable.offset)
+        query.limit(limit)
 
-        val count = Posts
-            .select { Posts.deleted eq false }
-            .andWhere(title) { Posts.title like "%$it%" }
-            .andWhere(category) { Posts.category eq it }
-            .count()
-
-        return PageImpl(PostDao.wrapRows(query).toList(), pageable, count).map { it.toDomain() }
+        return PostDao.wrapRows(query).toList().map { it.toDomain() }
     }
 
     override fun getCategoryCounts(): List<CategoryDto> {
@@ -100,10 +96,10 @@ class PostRepositoryImpl : PostRepository {
     }
 
     private fun <T> Query.andWhere(
-        parameter: Optional<T>,
+        parameter: T?,
         andPart: SqlExpressionBuilder.(T) -> Op<Boolean>
     ) = apply {
-        parameter.ifPresent {
+        parameter?.let {
             val expr = Op.build { andPart(it) }
 
             this.adjustWhere {

--- a/src/main/kotlin/com/example/blog/post/services/PostService.kt
+++ b/src/main/kotlin/com/example/blog/post/services/PostService.kt
@@ -7,11 +7,9 @@ import com.example.blog.post.domains.PostDomain
 import com.example.blog.post.domains.UpdatePost
 import com.example.blog.post.services.ports.PostRepository
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.*
+import java.time.LocalDateTime
 
 @Service
 @Transactional
@@ -24,9 +22,14 @@ class PostService(
         return postRepository.save(post).toDto()
     }
 
-    //TODO: Page 객체를 사용하지 않는 것이 좋음, none offset pagination 으로 수정예정
-    fun getPosts(pageable: Pageable, title: Optional<String>, category: Optional<String>): Page<PostDto> {
-        return postRepository.getByTitleAndCategory(pageable, title, category).map { it.toDto() }
+    fun getPosts(
+        limit: Int,
+        title: String?,
+        category: String?,
+        lastId: Long? = null,
+        lastCreatedAt: LocalDateTime? = null
+    ): List<PostDto> {
+        return postRepository.getByTitleAndCategory(limit, title, category, lastId, lastCreatedAt).map { it.toDto() }
     }
 
     fun getPost(postId: Long): PostDto {

--- a/src/main/kotlin/com/example/blog/post/services/ports/PostRepository.kt
+++ b/src/main/kotlin/com/example/blog/post/services/ports/PostRepository.kt
@@ -2,8 +2,7 @@ package com.example.blog.post.services.ports
 
 import com.example.blog.dto.CategoryDto
 import com.example.blog.post.domains.PostDomain
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
 import java.util.Optional
 
 interface PostRepository {
@@ -12,7 +11,13 @@ interface PostRepository {
 
     fun findById(id: Long): Optional<PostDomain>
 
-    fun getByTitleAndCategory(pageable: Pageable, title: Optional<String>, category: Optional<String>): Page<PostDomain>
+    fun getByTitleAndCategory(
+        limit: Int,
+        title: String?,
+        category: String?,
+        lastId: Long?,
+        lastCreatedAt: LocalDateTime?
+    ): List<PostDomain>
 
     fun getCategoryCounts(): List<CategoryDto>
 


### PR DESCRIPTION
- 포스트 조회 시 기존 offset 페이지네이션에서 cursor 페이지네이션을 적용합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 게시물 조회에 커서 기반 페이지네이션 도입으로 대용량 목록 탐색 효율성 향상
  - 커서와 제한 수를 이용해 게시물을 조회하는 새로운 API 엔드포인트 추가
  - 응답에 다음 게시물 조회를 위한 커서 문자열 포함

- **Improvements**
  - 게시물 조회 시 제목 및 카테고리 필터링 옵션 강화
  - 페이지네이션 로직 간소화로 부드러운 탐색 경험 제공

- **Chores**
  - Base64 인코딩/디코딩을 활용한 JSON 직렬화 유틸리티 추가
  - 게시물 조회 응답에 게시물 목록과 커서 정보를 포함하는 데이터 구조 도입
  - 내부 확장 함수 및 유틸리티 코드 정리 및 재배치
<!-- end of auto-generated comment: release notes by coderabbit.ai -->